### PR TITLE
Added support for fluentd extraEnvs

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -148,6 +148,7 @@ Fluentd is supplied only when kafka.enabled is set to true.
 | fluentd.imageTag | Fluentd image tag | "v1.12-debian-kafka-1" |
 | fluentd.replicas | Number of fluentd instances | 1 |
 | fluentd.affinity | Fluentd pod affinity definition | {} |
+| fluentd.extraEnvs | Additional configuration for fluentd | "" |
 | fluentd.priority_class | Fluentd pod priority class | "" |
 | fluentd.resources | Fluentd pod resource definition | {} |
 | fluentd.tolerarions | Fluentd pod tolerations definition | [] |

--- a/charts/templates/fluentd/fluentd-deployment.yaml
+++ b/charts/templates/fluentd/fluentd-deployment.yaml
@@ -65,6 +65,9 @@ spec:
           value:  {{ .Values.elasticsearch.user }}
         - name: FLUENT_ELASTICSEARCH_PASSWORD
           value:  {{ .Values.elasticsearch.password }}
+        {{- if .Values.fluentd.extraEnvs }}
+          {{- toYaml .Values.fluentd.extraEnvs | nindent 8 }}
+        {{- end }}
         livenessProbe:        
           httpGet:
             path: /metrics


### PR DESCRIPTION
Hi! 

Could you please review this slight modification in fluentd deployment file? It's purpose is to allow additional customization of the container (eg. Proxy). I've also added the field in README.

Thanks!

