### PR TITLE
Add extraEnvs to fluentbit

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -164,6 +164,7 @@ Used for multiple application startup checks.
 | fluentbit.containersLogsHostPath | Path location of the containers logs on the cluster nodes | "/var/log" |
 | fluentbit.journalsLogsHostPath | Path location of the systemd logs on the cluster nodes. On minikube change to "/run/log" | "/var/log" |
 | fluentbit.affinity | Fluentbit pod affinity definition | {} |
+| fluentbit.extraEnvs | Additional configuration for fluentbit | "" |
 | fluentbit.priorityClass | Fluentbit pod priority class | "" |
 | fluentbit.resources | Fluentbit pod resource definition | {} |
 | fluentbit.tolerarions | Fluentbit pod tolerations definition. All tainted nodes needs to be reflected in the tolerations array | [] |

--- a/charts/templates/fluentbit/fluentbit-daemonset.yaml
+++ b/charts/templates/fluentbit/fluentbit-daemonset.yaml
@@ -72,6 +72,9 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-opensearch-credentials-admin
               key: password
+        {{- if .Values.fluentbit.extraEnvs }}
+          {{- toYaml .Values.fluentbit.extraEnvs | nindent 8 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/v1/health

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -209,6 +209,7 @@ fluentbit:
     enabled: false
     interval: "30s"
     namespace: {}
+  extraEnvs: {}
 
 ## Logstash is the recommended approach for delivering log stream to opensearch
 ## kafka -> logstash -> opensearch
@@ -259,6 +260,7 @@ fluentd:
   #  labelSelector:
   #    matchLabels:
   #      k8s-app: fluentd
+  extraEnvs: {}
 
 # In scaled out setup kafka queues are used as ingestion points to accommodate
 # spiked in the logging stream volumes.


### PR DESCRIPTION
extraEnvs is already present in:
- opensearch_dashboards
- fluentd

Adding the same for `fluentbit`

NOTE:
extraEnvs was already set in fluentd/fluentd-deployment.yaml, but was not "exposed" in values.yaml.

Also added the same values to fluentbit/fluentbit-daemonset.yaml and values.

Added as I had need for additional environment variables, so cloned the setup.