### PR TITLE
Allow for multiple hosts to be specified via values.yaml

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -143,6 +143,8 @@ Used for multiple application startup checks.
 | opensearch_dashboards.readonly.user | Readonly user in opensearch-dashboards | "viewer" |
 | opensearch_dashboards.readonly.password | Password for the readonly user | "viewer" |
 | opensearch_dashboards.ingress.enabled | When enabled exposes opensearch-dashboards endpoint as an ingress | false |
+| opensearch_dashboards.ingress.host | Single hostname | "" |
+| opensearch_dashboards.ingress.hosts | Reference multiple hostnames  | {} |
 | opensearch_dashboards.ingress.path | Default context path for the ingress | "/" |
 | opensearch_dashboards.ingress.annotations | Any additional ingress controller specific annotations | {} |
 | opensearch_dashboards.ingress.tls | TLS ingress configuration | {} |
@@ -164,6 +166,7 @@ Used for multiple application startup checks.
 | fluentbit.containersLogsHostPath | Path location of the containers logs on the cluster nodes | "/var/log" |
 | fluentbit.journalsLogsHostPath | Path location of the systemd logs on the cluster nodes. On minikube change to "/run/log" | "/var/log" |
 | fluentbit.affinity | Fluentbit pod affinity definition | {} |
+| fluentbit.extraEnvs | Additional configuration for fluentbit | "" |
 | fluentbit.priorityClass | Fluentbit pod priority class | "" |
 | fluentbit.resources | Fluentbit pod resource definition | {} |
 | fluentbit.tolerarions | Fluentbit pod tolerations definition. All tainted nodes needs to be reflected in the tolerations array | [] |

--- a/charts/templates/opensearch-dashboards/opensearch-dashboards-config-sec.yaml
+++ b/charts/templates/opensearch-dashboards/opensearch-dashboards-config-sec.yaml
@@ -37,7 +37,13 @@ stringData:
     {{- end }}
     opensearch_security.openid.client_id: {{ .Values.opensearch.oidc.clientId }}
     opensearch_security.openid.client_secret: {{ .Values.opensearch.oidc.clientSecret }}
+    {{- if .Values.opensearch_dashboards.ingress.host }}
     opensearch_security.openid.base_redirect_url: https://{{ .Values.opensearch_dashboards.ingress.host }}
+    {{- else }}
+    {{- with (first .Values.opensearch_dashboards.ingress.hosts) }}
+    opensearch_security.openid.base_redirect_url: https://{{ . }}
+    {{- end }}
+    {{- end }}
     opensearch_security.openid.logout_url: {{ .Values.opensearch.oidc.logoutUrl }}
     opensearch_security.openid.scope: {{ .Values.opensearch.oidc.scope }}
 {{- end }}

--- a/charts/templates/opensearch-dashboards/opensearch-dashboards-ingress.yaml
+++ b/charts/templates/opensearch-dashboards/opensearch-dashboards-ingress.yaml
@@ -13,6 +13,7 @@ spec:
     {{- toYaml . | nindent 4}}
   {{- end }}
   rules:
+  {{- if .Values.opensearch_dashboards.ingress.host }}
   - host: {{ .Values.opensearch_dashboards.ingress.host }}
     http:
       paths:
@@ -23,4 +24,20 @@ spec:
             name: {{ .Release.Name }}-opensearch-dashboards
             port:
               number: 5601
+  {{- end }}
+  {{- if .Values.opensearch_dashboards.ingress.hosts }}
+    {{- $root := . -}}
+    {{- range $host := .Values.opensearch_dashboards.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+      - path: {{ $root.Values.opensearch_dashboards.ingress.path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $root.Release.Name }}-opensearch-dashboards
+            port:
+              number: 5601
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -146,6 +146,7 @@ opensearch_dashboards:
     password: "develop"
   ingress:
     host: {}
+    hosts: {}
     path: "/"
     enabled: false
     annotations: {}
@@ -209,6 +210,7 @@ fluentbit:
     enabled: false
     interval: "30s"
     namespace: {}
+  extraEnvs: {}
 
 ## Logstash is the recommended approach for delivering log stream to opensearch
 ## kafka -> logstash -> opensearch
@@ -259,6 +261,7 @@ fluentd:
   #  labelSelector:
   #    matchLabels:
   #      k8s-app: fluentd
+  extraEnvs: {}
 
 # In scaled out setup kafka queues are used as ingestion points to accommodate
 # spiked in the logging stream volumes.


### PR DESCRIPTION
PR for issue: https://github.com/nickytd/kubernetes-logging-helm/issues/11

Currently, we have access to only 1 host name:
`opensearch_dashboards.ingress.host`

This means, when I create a DNS entry under my own domain, I must wait until the `ingress` is created, and depending on which hyperscaler I am on, either use an AWS load balancer CNAME or on Azure, use the IP address assigned.

I had noticed with ELK, I could create multiple hosts, and was able to use a DNS name for the cluster.  So this name would always resolve.

It looks something like this in values.yaml:
```
opensearch_dashboards:
  ingress:
    enabled: true 
    hosts: 
      - logs-os.sandbox.my.domain
      - kibana.ingress.sandboxbsh-a.iotdevk8s.shoot.canary.k8s-hana.some.com
```
This will generate the following ingress:
```
  - host: logs-os.sandbox.my.domain
    http:
      paths:
      - backend:
          service:
            name: ofd-opensearch-dashboards
            port:
              number: 5601
        path: /
        pathType: Prefix
  - host: dashboards.ingress.sandboxbsh-a.iotdevk8s.shoot.canary.some.com
    http:
      paths:
      - backend:
          service:
            name: ofd-opensearch-dashboards
            port:
              number: 5601
        path: /
        pathType: Prefix
```

Which means, when I create the DNS entry:
`logs-os.sandbox.my.domain`
I can point it at the automatically exposed hostname:
`kibana.ingress.sandboxbsh-a.iotdevk8s.shoot.canary.k8s-hana.some.com`

And then don't have to mess around with my DNS entries after the fact.

PR is completed and tested.

It allows for backwards compatibility if you continue to use:
```
opensearch_dashboards:
  ingress:
    enabled: true 
    host: 
```
But it will also check for:
```
opensearch_dashboards:
  ingress:
    enabled: true 
    hosts: 
```
