### PR TITLE
Fluentbit custom config issue #8

### DIFF
--- a/charts/templates/fluentbit/fluentbit-config.yaml
+++ b/charts/templates/fluentbit/fluentbit-config.yaml
@@ -30,18 +30,18 @@ data:
         storage.metrics           on
 
 
-    @INCLUDE input-*.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE filter-de_dot.conf
-    @INCLUDE filter-rewrite.conf
-    @INCLUDE filter-parser.conf
+    @INCLUDE input-stock-*.conf
+    @INCLUDE input-custom-*.conf
+    @INCLUDE filter-stock-*.conf
+    @INCLUDE filter-custom-*.conf
     {{- if .Values.kafka.enabled }}
-    @INCLUDE output-kafka.conf
+    @INCLUDE output-stock-kafka.conf
     {{- else }}
-    @INCLUDE output-opensearch-*.conf
+    @INCLUDE output-stock-opensearch-*.conf
     {{- end }}
+    @INCLUDE output-custom-*.conf
         
-  input-kubernetes.conf: |-
+  input-stock-kubernetes.conf: |-
     [INPUT]
         Name              tail
         Tag               kube.<pod_id>.<namespace_name>.<pod_name>.<container_name>
@@ -58,7 +58,7 @@ data:
         Log_Level         Off
         multiline.parser  cri, docker, go, python, java
 
-  input-systemd.conf: |-
+  input-stock-systemd.conf: |-
     [INPUT]
         Name                systemd
         Tag                 systemd.*
@@ -69,7 +69,7 @@ data:
         Path                /run/log/journal
         Strip_Underscores   On
   
-  filter-kubernetes.conf: |-
+  filter-stock-kubernetes.conf: |-
     [FILTER]
         Name                kubernetes
         Match               kube.*
@@ -86,20 +86,20 @@ data:
         Kube_Meta_Cache_TTL 60s
         Annotations         Off
 
-  filter-de_dot.conf: |-
+  filter-stock-de_dot.conf: |-
     [FILTER]
         Name    lua
         Match   kube.*
         script  /fluent-bit/etc/dedot.lua
         call    dedot
 
-  filter-rewrite.conf: |-
+  filter-stock-rewrite.conf: |-
     [FILTER]
         Name          rewrite_tag
         Match         kube.*
         Rule          $kubernetes['labels']['app_kubernetes_io/name'] "^(ingress-nginx)$" nginx false
 
-  filter-parser.conf: |-
+  filter-stock-parser.conf: |-
     [FILTER]
         Name                parser
         Match               nginx
@@ -107,7 +107,7 @@ data:
         Parser              k8s-nginx-ingress
         Reserve_Data        True
 
-  output-opensearch-nginx.conf: |-
+  output-stock-opensearch-nginx.conf: |-
     [OUTPUT]
         Name                es
         Match               nginx
@@ -130,7 +130,7 @@ data:
         tls.crt_file        /fluent-bit/ssl/admin.pem
         tls.key_file        /fluent-bit/ssl/admin-key.pem
 
-  output-opensearch-journals.conf: |-
+  output-stock-opensearch-journals.conf: |-
     [OUTPUT]
         Name                es
         Match               systemd.*
@@ -153,7 +153,7 @@ data:
         tls.crt_file        /fluent-bit/ssl/admin.pem
         tls.key_file        /fluent-bit/ssl/admin-key.pem
 
-  output-opensearch-containers.conf: |-
+  output-stock-opensearch-containers.conf: |-
     [OUTPUT]
         Name                es
         Match               kube.*
@@ -176,7 +176,7 @@ data:
         tls.crt_file        /fluent-bit/ssl/admin.pem
         tls.key_file        /fluent-bit/ssl/admin-key.pem
 
-  output-kafka.conf: |-
+  output-stock-kafka.conf: |-
     [OUTPUT]
         Name                          kafka
         Match                         *
@@ -189,27 +189,6 @@ data:
         rdkafka.message.max.bytes             10000000
         rdkafka.queue.buffering.max.ms        50
         rdkafka.client.id                     ${HOSTNAME}
-
-  parsers.conf: |-
-    [PARSER]
-        Name        k8s-nginx-ingress
-        Format      regex
-        Regex       ^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referrer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
-        Time_Key    time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-        
-    [PARSER]
-        # https://github.com/Yolean/fluent-bit-kubernetes-logging/blob/kustomize-base/base/parser-cri.conf#L9
-        Name        kube-tag
-        Format      regex
-        Regex       ^(?<pod_id>[^.]+)\.(?<namespace_name>[^.]+)\.(?<pod_name>[^.]+)\.(?<container_name>[^.]+)$
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
 
   dedot.lua: |-
     function dedot(tag, timestamp, record)
@@ -241,3 +220,45 @@ data:
             map[k] = v
         end
     end
+
+  parsers.conf: |-
+    [PARSER]
+        Name        k8s-nginx-ingress
+        Format      regex
+        Regex       ^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referrer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
+        Time_Key    time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+        
+    [PARSER]
+        # https://github.com/Yolean/fluent-bit-kubernetes-logging/blob/kustomize-base/base/parser-cri.conf#L9
+        Name        kube-tag
+        Format      regex
+        Regex       ^(?<pod_id>[^.]+)\.(?<namespace_name>[^.]+)\.(?<pod_name>[^.]+)\.(?<container_name>[^.]+)$
+
+    [PARSER]
+        Name        syslog
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S
+
+    # Appending any additional parsers from fluentbit-custom-files
+    # Using https://github.com/Masterminds/sprig/blob/master/regex.go
+{{- range $path, $_ := .Files.Glob "fluentbit-custom-files/*" }}
+{{- if $path | regexMatch ".*parser.*" }}
+
+{{ printf "#%s" $path | nindent 4 }}
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}
+
+
+{{- range $path, $_ := .Files.Glob "fluentbit-custom-files/*" }}
+{{- if not ($path | regexMatch ".*parser.*") }}
+
+  {{ regexReplaceAll "(.*)/" $path "" }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}
+
+

--- a/charts/templates/fluentbit/fluentbit-config.yaml
+++ b/charts/templates/fluentbit/fluentbit-config.yaml
@@ -92,12 +92,6 @@ data:
         script  /fluent-bit/etc/dedot.lua
         call    dedot
 
-  filter-stock-rewrite.conf: |-
-    [FILTER]
-        Name          rewrite_tag
-        Match         kube.*
-        Rule          $kubernetes['labels']['app_kubernetes_io/name'] "^(ingress-nginx)$" nginx false
-
   filter-stock-parser.conf: |-
     [FILTER]
         Name                parser
@@ -105,6 +99,12 @@ data:
         Key_Name            log
         Parser              k8s-nginx-ingress
         Reserve_Data        True
+
+  filter-stock-rewrite.conf: |-
+    [FILTER]
+        Name          rewrite_tag
+        Match         kube.*
+        Rule          $kubernetes['labels']['app_kubernetes_io/name'] "^(ingress-nginx)$" nginx false
 
   output-stock-opensearch-nginx.conf: |-
     [OUTPUT]
@@ -177,17 +177,17 @@ data:
 
   output-stock-kafka.conf: |-
     [OUTPUT]
-        Name                          kafka
-        Match                         *
-        Brokers                       {{ include "kafkaBrokers" (dict "replicas" .Values.kafka.replicas "releaseName" $.Release.Name) }}
-        Topics                        containers
-        Retry_Limit                   False
-        timestamp_format              iso8601
-        rdkafka.log.connection.close          false
-        rdkafka.request.required.acks         all
-        rdkafka.message.max.bytes             10000000
-        rdkafka.queue.buffering.max.ms        50
-        rdkafka.client.id                     ${HOSTNAME}
+        Name                             kafka
+        Match                            *
+        Brokers                          {{ include "kafkaBrokers" (dict "replicas" .Values.kafka.replicas "releaseName" $.Release.Name) }}
+        Topics                           containers
+        Retry_Limit                      False
+        timestamp_format                 iso8601
+        rdkafka.log.connection.close     false
+        rdkafka.request.required.acks    all
+        rdkafka.message.max.bytes        10000000
+        rdkafka.queue.buffering.max.ms   50
+        rdkafka.client.id                ${HOSTNAME}
 
   dedot.lua: |-
     function dedot(tag, timestamp, record)
@@ -242,7 +242,10 @@ data:
         Time_Format %b %d %H:%M:%S
 
     # Appending any additional parsers from fluentbit-custom-files
-    # Using https://github.com/Masterminds/sprig/blob/master/regex.go
+    # parsers.conf must be the LAST file as parsers.conf 
+    # does NOT support the @INCLUDE syntax to append more.
+    #
+    # Using regexMatch (and others) from https://github.com/Masterminds/sprig/blob/master/regex.go
 
 {{- range $path, $_ := .Files.Glob "fluentbit-custom-files/*" }}
 {{- if $path | regexMatch ".*parser.*" }}

--- a/charts/templates/fluentbit/fluentbit-config.yaml
+++ b/charts/templates/fluentbit/fluentbit-config.yaml
@@ -9,26 +9,25 @@ data:
   # ======================================================
   fluent-bit.conf: |-
     [SERVICE]
-        Flush                     1
-        Log_Level                 info
-        Daemon                    off
-        Parsers_File              parsers.conf
-        HTTP_Server               On
-        HTTP_Listen               0.0.0.0
-        HTTP_Port                 2020
+        Flush                         1
+        Log_Level                     debug
+        Daemon                        off
+        Parsers_File                  parsers.conf
+        HTTP_Server                   On
+        HTTP_Listen                   0.0.0.0
+        HTTP_Port                     2020
         net.connect_timeout_log_error true
         net.connect_timeout           100
         net.keepalive                 on
         net.keepalive_idle_timeout    60
         net.dns.mode                  TCP
-        storage.type              filesystem
-        storage.path              /var/log/flb-storage/
-        storage.sync              normal
-        storage.checksum          off
-        storage.backlog.mem_limit 50M
-        storage.max_chunks_up     1000
-        storage.metrics           on
-
+        storage.type                  filesystem
+        storage.path                  /var/log/flb-storage/
+        storage.sync                  normal
+        storage.checksum              off
+        storage.backlog.mem_limit     50M
+        storage.max_chunks_up         1000
+        storage.metrics               on
 
     @INCLUDE input-stock-*.conf
     @INCLUDE input-custom-*.conf
@@ -40,7 +39,7 @@ data:
     @INCLUDE output-stock-opensearch-*.conf
     {{- end }}
     @INCLUDE output-custom-*.conf
-        
+
   input-stock-kubernetes.conf: |-
     [INPUT]
         Name              tail
@@ -55,7 +54,7 @@ data:
         Skip_Long_Lines   Off
         Refresh_Interval  10
         Read_from_Head    False
-        Log_Level         Off
+        Log_Level         debug
         multiline.parser  cri, docker, go, python, java
 
   input-stock-systemd.conf: |-
@@ -63,12 +62,12 @@ data:
         Name                systemd
         Tag                 systemd.*
         Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
-        Systemd_Filter      _SYSTEMD_UNIT={{.Values.fluentbit.containersRuntime}}.service        
+        Systemd_Filter      _SYSTEMD_UNIT={{.Values.fluentbit.containersRuntime}}.service
         Systemd_Filter_Type Or
-        Read_From_Tail      On    
+        Read_From_Tail      On
         Path                /run/log/journal
         Strip_Underscores   On
-  
+
   filter-stock-kubernetes.conf: |-
     [FILTER]
         Name                kubernetes
@@ -166,7 +165,7 @@ data:
         Replace_Dots        On
         Retry_Limit         False
         Trace_Error         On
-        Suppress_Type_Name  On     
+        Suppress_Type_Name  On
         Include_Tag_Key     Off
         Time_Key_Nanos      Off
         Generate_ID         On
@@ -228,7 +227,7 @@ data:
         Regex       ^(?<host>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referrer>[^\"]*)" "(?<agent>[^\"]*)" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] (\[(?<proxy_alternative_upstream_name>[^ ]*)\] )?(?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
         Time_Key    time
         Time_Format %d/%b/%Y:%H:%M:%S %z
-        
+
     [PARSER]
         # https://github.com/Yolean/fluent-bit-kubernetes-logging/blob/kustomize-base/base/parser-cri.conf#L9
         Name        kube-tag
@@ -244,21 +243,18 @@ data:
 
     # Appending any additional parsers from fluentbit-custom-files
     # Using https://github.com/Masterminds/sprig/blob/master/regex.go
+
 {{- range $path, $_ := .Files.Glob "fluentbit-custom-files/*" }}
 {{- if $path | regexMatch ".*parser.*" }}
-
+{{ printf "" | nindent 4 }}
 {{ printf "#%s" $path | nindent 4 }}
 {{ $.Files.Get $path | indent 4 }}
 {{- end }}
 {{- end }}
 
-
 {{- range $path, $_ := .Files.Glob "fluentbit-custom-files/*" }}
 {{- if not ($path | regexMatch ".*parser.*") }}
-
-  {{ regexReplaceAll "(.*)/" $path "" }}: |
+{{ regexReplaceAll "(.*)/" $path "" | indent 2 }}: |-
 {{ $.Files.Get $path | indent 4 }}
 {{- end }}
 {{- end }}
-
-


### PR DESCRIPTION
We need to customize the Fluent Bit Parsers for our distribution to:
- Provide a list of files / directories to scan of our own pods
- Custom parsers to deal with those format of those files
- Extra gear for Fluent Bit like RecordModifiers and such

I see the parsers specified in `charts/templates/fluentbit/fluentbit-config.yaml`

Within that file are all the parsers that I would like to typically append to.
- fluent-bit.confg
- input-kubernetes.confg
- input-systemd.confg
- filter-kubernetes.confg
- filter-parser.confg
- filter-rewrite.confg
- output-opensearch-nginx.confg
- output-opensearch-journals.confg
- output-opensearch-containers.confg
- output-kafka.confg
- parsers.confg


`charts\templates\fluentbit\fluentbit-config.yaml` has a specific setup inside the file:
```
  fluent-bit.conf: |-
    [SERVICE]
        Flush                         35
        Log_Level                     error
        Daemon                        off
        Parsers_File                  parsers.conf
        HTTP_Server                   On
        HTTP_Listen                   0.0.0.0
        HTTP_Port                     2020
        net.connect_timeout_log_error true
        net.connect_timeout           100
        net.keepalive                 on
        net.keepalive_idle_timeout    60
        net.dns.mode                  TCP
        storage.type                  filesystem
        storage.path                  /var/log/flb-storage/
        storage.sync                  normal
        storage.checksum              off
        storage.backlog.mem_limit     50M
        storage.max_chunks_up         1000
        storage.metrics               on

    @INCLUDE input-*.conf
    @INCLUDE filter-kubernetes.conf
    @INCLUDE filter-parser.conf
```

I have done this in his PR by changing all existing file definitions to be in this format:
- input-stock-*.confg
- filter-stock-*.confg
- output-stock-*.confg

I have then changed and added additional includes:
```
    @INCLUDE input-stock-*.conf
    @INCLUDE filter-stock-*.conf
    @INCLUDE output-stock-*.conf
    @INCLUDE input-custom-*.conf
    @INCLUDE filter-custom-*.conf
    @INCLUDE output-custom-*.conf
```

This will allow us to use Helm to append additional files to `fluentbit-config.yaml` and not disturb the existing configuration.

I could not follow the same approach with:
```
        Parsers_File                  parsers.conf
```
as it does not support the `@INCLUDE` syntax.
This means, we can only append to it.
Due to this, I have moved this file to the bottom of the `fluentbit-config.yaml`

Next, the Helm charts will check for the existence of the directory `charts/fluentbit-custom-files`.

If found it will:
1. Find any file with `parser` within it's name and append it to the `parsers.conf`.
2. It will append each file that does not contain `parser` to the bottom of `fluentbit-config.yaml` using this format:

```
  filename1: |-  (indent 2)
    filename1 contents (indent 4)
  filename2: |-  (indent 2)
    filename2 contents (indent 4)
```

I have all of this working, though, I do not know how to document it.
Do we want a separate section in `charts/README.md` about customizing FluentBit?

