### PR TITLE
Add support for fractional seconds

### DIFF
--- a/chart/index-pipelines/01_filter.conf
+++ b/chart/index-pipelines/01_filter.conf
@@ -5,33 +5,16 @@ filter {
     target => "[@metadata][uuid]"
   }
 
-  #some logs keep timestamps in ts field
-  if [ts] {
-    date {
-        match => [ "ts", "MMM dd, yyyy @ HH:mm:ss.SSS", "ISO8601" ]
-        target => "@timestamp"
-        tag_on_failure => ["_dateparsefailure"]
-        remove_field => ["ts"]
-    }
-  }
-
-  if [time] {
-    date {
-        match => [ "time", "MMM dd, yyyy @ HH:mm:ss.SSS", "ISO8601" ]
-        target => "@timestamp"
-        tag_on_failure => ["_dateparsefailure"]
-        remove_field => ["time"]
-    }
-  }
-
-  #some logs keep timestamps in timestamp field
-  if [timestamp] {
-    date {
-        match => [ "timestamp", "MMM dd, yyyy @ HH:mm:ss.SSS", "ISO8601" ]
-        target => "@timestamp"
-        tag_on_failure => ["_dateparsefailure"]
-        remove_field => ["timestamp"]
-    }
+  ### Workarounds:
+  # - FluentBit not sent full precision to Kafka
+  #   details see: https://github.com/fluent/fluent-bit/issues/6132
+  #   we must discard field "@timestamp" from Kafka (have only partial precision)
+  #   and parse "time" field in LogStah again to get full precision
+  # - LogStash "date" parser not have support for fractional seconds
+  #   details see: https://github.com/elastic/logstash/issues/10822#issuecomment-1211851065
+  #   we must use Ruby parser to get full precision
+  ruby {
+    code => "event.set('[@timestamp]', LogStash::Timestamp.new(event.get('[time]')) )"
   }
 
 # end of filter

--- a/chart/index-templates/containers_index_template.json
+++ b/chart/index-templates/containers_index_template.json
@@ -23,6 +23,9 @@
             "enabled":true
          },
          "properties":{
+            "@timestamp":{
+              "type":"date_nanos"
+            },
             "level":{
                "type":"keyword"
             },

--- a/chart/index-templates/kubernetes-metadata_component_template.json
+++ b/chart/index-templates/kubernetes-metadata_component_template.json
@@ -32,9 +32,6 @@
             }
          ],
          "properties":{
-            "@timestamp":{
-               "type":"date"
-            },
             "location":{
                "type":"keyword"
             },

--- a/chart/index-templates/nginx_index_template.json
+++ b/chart/index-templates/nginx_index_template.json
@@ -24,6 +24,9 @@
             "enabled":true
          },
          "properties":{
+            "@timestamp":{
+              "type":"date"
+            },
             "log":{
                "type":"text"
             },

--- a/chart/templates/fluent-bit/fluent-bit-config-sec.yaml
+++ b/chart/templates/fluent-bit/fluent-bit-config-sec.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name}}-fluent-bit
+  name: {{ .Release.Name }}-fluent-bit
   labels: {{ include "logging.labels" . | indent 4 }}
     k8s-app: fluent-bit
 stringData:
@@ -89,7 +89,7 @@ stringData:
         Name                systemd
         Tag                 systemd.*
         Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
-        Systemd_Filter      _SYSTEMD_UNIT={{.Values.fluentbit.containersRuntime}}.service
+        Systemd_Filter      _SYSTEMD_UNIT={{ .Values.fluentbit.containersRuntime }}.service
         Systemd_Filter_Type Or
         Read_From_Tail      On
         Path                /run/log/journal
@@ -169,7 +169,7 @@ stringData:
         Trace_Error         On
         Suppress_Type_Name  On
         Include_Tag_Key     Off
-        Time_Key_Nanos      Off
+        Time_Key_Nanos      On
         Generate_ID         On
         tls                 On
         tls.Verify          On
@@ -231,6 +231,7 @@ stringData:
         Name        kube-tag
         Format      regex
         Regex       ^(?<pod_id>[^_/]+)\.(?<namespace_name>[^_/]+)\.(?<pod_name>[^_/]+)\.(?<container_name>[^/]+)$
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%Z
 
     [PARSER]
         Name        syslog


### PR DESCRIPTION
- when many components in cluster generate many log records in one seconds, log records will be missordered
- adding support for fractional seconds solve this problem
- only Docker logs timestamp is used

**Knowed problems:**
_Scaled multi nodes layer:_
FluentBit send only part of fractional seconds ([details](https://github.com/fluent/fluent-bit/issues/6132)) to Kafka, workaround below. When FluentBit Kafka output will support full precision ([PR was made](https://github.com/fluent/fluent-bit/pull/6395)), this workaround can be discarded (+ change FluentBit Kafka output plugin setting).

Changes will be affected on newly created indices!