### PR TITLE
Kafka crashes without advertising controller names

### DIFF
--- a/chart/templates/kafka/kafka-statefulset.yaml
+++ b/chart/templates/kafka/kafka-statefulset.yaml
@@ -78,6 +78,8 @@ spec:
           value: {{ .Values.kafka.kraftId }}
         - name: KAFKA_CFG_PROCESS_ROLES
           value: "broker,controller"
+        - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+          value: "CONTROLLER"
         - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
           value: {{ include "kafkaQuorum" (dict "replicas" .Values.kafka.replicas "releaseName" $.Release.Name) }}
         - name: KAFKA_CFG_LISTENERS


### PR DESCRIPTION
This is to fix Kafka crashed when env KAFKA_CFG_CONTROLLER_LISTENER_NAMES is not defined.